### PR TITLE
UI uodates: adds controls for text conversion mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Career Lab text-case formatter</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,45 @@
 header {
   background-color: #282c34;
   color: white;
-  margin-bottom: 20px;
-  padding: 20px 0;
+  margin-bottom: 2rem;
+  padding: 2rem 0;
   text-align: center;
 }
 
-main {
-    margin: 1rem auto;
-    max-width: 800px;
-    padding: 0 20px;
+form {
+  margin: 1.6rem auto;
+  max-width: 80rem;
+  max-width: 68ch;
+  padding: 0 2rem;
 }
 
 .form-control > * + *,
 .form-control__radio + .form-control__radio {
-    margin-top: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .form-control__text > label {
-    display: table;
+  display: table;
+  font-weight: 500;
 }
 
 .result-wrapper {
-    margin-top: 6rem;
+  margin-top: 6rem;
 }
 
 textarea,
 output {
-    width: 100%;
-    height: 6.4rem;
+	font-size: 1.4rem;
+  width: 100%;
+  height: 8.6rem;
+  padding: 0.75rem;
+
 }
 
 #result {
-    display: block;
-    border: solid 1px #282c34;
-    max-width: 800px;
-    overflow: auto;
-    padding: 1.6rem;
-    text-align: left;
-    white-space: pre;
+  display: block;
+  border: solid 1px #282c34;
+  overflow: auto;
+  text-align: left;
+  white-space: pre;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,32 +1,42 @@
-.App {
-    text-align: center;
-}
-
 header {
-    background-color: #282c34;
-    color: white;
-    margin-bottom: 20px;
-    padding: 20px 0;
+  background-color: #282c34;
+  color: white;
+  margin-bottom: 20px;
+  padding: 20px 0;
+  text-align: center;
 }
 
-form {
+main {
     margin: 1rem auto;
     max-width: 800px;
     padding: 0 20px;
 }
 
-textarea {
-    height: 4rem;
+.form-control > * + *,
+.form-control__radio + .form-control__radio {
+    margin-top: 0.5rem;
+}
+
+.form-control__text > label {
+    display: table;
+}
+
+.result-wrapper {
+    margin-top: 6rem;
+}
+
+textarea,
+output {
     width: 100%;
+    height: 6.4rem;
 }
 
 #result {
+    display: block;
     border: solid 1px #282c34;
-    height: auto;
-    margin: 1rem auto;
     max-width: 800px;
     overflow: auto;
-    padding: 1rem;
+    padding: 1.6rem;
     text-align: left;
     white-space: pre;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -29,16 +29,16 @@ form {
 
 textarea,
 output {
-	font-size: 1.4rem;
-  width: 100%;
+  border: solid 1px #282c34;
+  font-size: 1.4rem;
   height: 8.6rem;
   padding: 0.75rem;
+  width: 100%;
 
 }
 
 #result {
   display: block;
-  border: solid 1px #282c34;
   overflow: auto;
   text-align: left;
   white-space: pre;

--- a/src/App.css
+++ b/src/App.css
@@ -18,6 +18,10 @@ form {
   margin-top: 0.5rem;
 }
 
+.form-control__radio > label {
+	margin-left: 4px;
+}
+
 .form-control__text > label {
   display: table;
   font-weight: 500;

--- a/src/App.js
+++ b/src/App.js
@@ -3,12 +3,12 @@ import React from "react";
 
 function App() {
   const [textInput, setTextInput] = React.useState('Here is some example text.');
-	const [conversionMode, setConversionMode] = React.useState('lowercase');
+  const [conversionMode, setConversionMode] = React.useState('lowercase');
   const [textOutput, setTextOutput] = React.useState('');
 
-	const handleRadioChange = event => {
-		setConversionMode(event.target.value);
-	}
+  const handleRadioChange = event => {
+    setConversionMode(event.target.value);
+  }
 
   const handleTextareaChange = event => {
     setTextInput(event.target.value);

--- a/src/App.js
+++ b/src/App.js
@@ -3,9 +3,14 @@ import React from "react";
 
 function App() {
   const [textInput, setTextInput] = React.useState('Here is some example text.');
+	const [conversionMode, setConversionMode] = React.useState('lowercase');
   const [textOutput, setTextOutput] = React.useState('');
 
-  const handleChange = event => {
+	const handleRadioChange = event => {
+		setConversionMode(event.target.value);
+	}
+
+  const handleTextareaChange = event => {
     setTextInput(event.target.value);
   };
 
@@ -23,14 +28,32 @@ function App() {
         <form onSubmit={handleSubmit}>
           <div className="form-control form-control__text">
             <label for="text">Text to be formatted:</label>
-            <textarea id="text" onChange={handleChange} value={textInput} />
+            <textarea
+              id="text"
+              onChange={handleTextareaChange}
+              value={textInput}
+            />
           </div>
           <div className="form-control form-control__radio">
-            <input type="radio" name="conversion" id="conversion-0" />
+            <input
+              type="radio"
+              name="conversion"
+              id="conversion-0"
+              value="lowercase"
+              checked={conversionMode === "lowercase"}
+              onChange={handleRadioChange}
+            />
             <label for="conversion-0">&nbsp;Convert text to lowercase</label>
           </div>
           <div className="form-control form-control__radio">
-            <input type="radio" name="conversion" id="conversion-1" />
+            <input
+              type="radio"
+              name="conversion"
+              id="conversion-1"
+              value="uppercase"
+              checked={conversionMode === "uppercase"}
+              onChange={handleRadioChange}
+            />
             <label for="conversion-1">&nbsp;Convert text to uppercase</label>
           </div>
           <input type="submit" value="Submit" />

--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,7 @@ function App() {
               checked={conversionMode === "lowercase"}
               onChange={handleRadioChange}
             />
-            <label htmlFor="conversion-0">&nbsp;Convert text to lowercase</label>
+            <label htmlFor="conversion-0">Convert text to lowercase</label>
           </div>
           <div className="form-control form-control__radio">
             <input
@@ -53,7 +53,7 @@ function App() {
               checked={conversionMode === "uppercase"}
               onChange={handleRadioChange}
             />
-            <label htmlFor="conversion-1">&nbsp;Convert text to uppercase</label>
+            <label htmlFor="conversion-1">Convert text to uppercase</label>
           </div>
           <input type="submit" value="Submit" />
           <div className="result-wrapper form-control form-control__text">

--- a/src/App.js
+++ b/src/App.js
@@ -22,11 +22,11 @@ function App() {
   return (
     <div className="App">
       <header>
-        <h1>Career Lab | Take-Home Assignment</h1>
+        <h1>Career Lab text-case converter</h1>
       </header>
         <form onSubmit={handleSubmit}>
           <div className="form-control form-control__text">
-            <label htmlFor="text">Text to be formatted:</label>
+            <label htmlFor="text">Text to be converted:</label>
             <textarea
               id="text"
               onChange={handleTextareaChange}
@@ -57,7 +57,7 @@ function App() {
           </div>
           <input type="submit" value="Submit" />
           <div className="result-wrapper form-control form-control__text">
-            <label htmlFor="result">Formatted text:</label>
+            <label htmlFor="result">Converted text:</label>
             <output id="result">{textOutput}</output>
           </div>
         </form>

--- a/src/App.js
+++ b/src/App.js
@@ -19,15 +19,27 @@ function App() {
       <header>
         <h1>Career Lab | Take-Home Assignment</h1>
       </header>
-      <form onSubmit={handleSubmit}>
-        <label>
-          <textarea onChange={handleChange} value={textInput}/>
-        </label>
-        <input type="submit" value="Submit"/>
-      </form>
-      <div id="result">
-        {textOutput}
-      </div>
+      <main>
+        <form onSubmit={handleSubmit}>
+          <div className="form-control form-control__text">
+            <label for="text">Text to be formatted:</label>
+            <textarea id="text" onChange={handleChange} value={textInput} />
+          </div>
+          <div className="form-control form-control__radio">
+            <input type="radio" name="conversion" id="conversion-0" />
+            <label for="conversion-0">&nbsp;Convert text to lowercase</label>
+          </div>
+          <div className="form-control form-control__radio">
+            <input type="radio" name="conversion" id="conversion-1" />
+            <label for="conversion-1">&nbsp;Convert text to uppercase</label>
+          </div>
+          <input type="submit" value="Submit" />
+        </form>
+        <div className="result-wrapper form-control form-control__text">
+          <label for="result">Formatted text:</label>
+          <output id="result">{textOutput}</output>
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,7 @@ function App() {
       </header>
         <form onSubmit={handleSubmit}>
           <div className="form-control form-control__text">
-            <label for="text">Text to be formatted:</label>
+            <label htmlFor="text">Text to be formatted:</label>
             <textarea
               id="text"
               onChange={handleTextareaChange}
@@ -42,7 +42,7 @@ function App() {
               checked={conversionMode === "lowercase"}
               onChange={handleRadioChange}
             />
-            <label for="conversion-0">&nbsp;Convert text to lowercase</label>
+            <label htmlFor="conversion-0">&nbsp;Convert text to lowercase</label>
           </div>
           <div className="form-control form-control__radio">
             <input
@@ -53,11 +53,11 @@ function App() {
               checked={conversionMode === "uppercase"}
               onChange={handleRadioChange}
             />
-            <label for="conversion-1">&nbsp;Convert text to uppercase</label>
+            <label htmlFor="conversion-1">&nbsp;Convert text to uppercase</label>
           </div>
           <input type="submit" value="Submit" />
           <div className="result-wrapper form-control form-control__text">
-            <label for="result">Formatted text:</label>
+            <label htmlFor="result">Formatted text:</label>
             <output id="result">{textOutput}</output>
           </div>
         </form>

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,6 @@ function App() {
       <header>
         <h1>Career Lab | Take-Home Assignment</h1>
       </header>
-      <main>
         <form onSubmit={handleSubmit}>
           <div className="form-control form-control__text">
             <label for="text">Text to be formatted:</label>
@@ -57,12 +56,11 @@ function App() {
             <label for="conversion-1">&nbsp;Convert text to uppercase</label>
           </div>
           <input type="submit" value="Submit" />
+          <div className="result-wrapper form-control form-control__text">
+            <label for="result">Formatted text:</label>
+            <output id="result">{textOutput}</output>
+          </div>
         </form>
-        <div className="result-wrapper form-control form-control__text">
-          <label for="result">Formatted text:</label>
-          <output id="result">{textOutput}</output>
-        </div>
-      </main>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,38 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+}
+
+* + * {
+  margin-top: 0.75rem;
+}
+
+html {
+  font-size: 62.5%;
+}
+
+#root,
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+}
+
+body {
+  font-size: 1.6rem;
+  line-height: 1.15;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+input[type="submit"] {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: inherit;
+}
+
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }


### PR DESCRIPTION
## Summary

As discussed in last the recent career lab mentor onboarding, this PR adds controls that allow the user to select which conversion mode to target (uppercase or lowercase).

![CleanShot 2021-09-06 at 13 23 15@2x](https://user-images.githubusercontent.com/13525251/132258947-a75dc9f9-8321-4a40-b61c-a19d03034245.png)

## Other changes

- Adds `onChange` functionality to track which radio is selected
- Reorganizes the HTML to use label + input siblings, rather than label > input nests (mainly to make it easier to style those labels)
- Styles spacing & sizes with relative units, rather than pixels
- Normalizes some whitespace in the files

**Note:** It might be easier to review my code changes using the `hide whitespace-only changes` option!
